### PR TITLE
Use tag-lists for capital-cost variables

### DIFF
--- a/definitions/variable/techno-economic/techno-economic-parameters.yaml
+++ b/definitions/variable/techno-economic/techno-economic-parameters.yaml
@@ -1,189 +1,77 @@
-- Capital Cost|Electricity|Biomass|w/ CCS:
-    description: capital cost of a new biomass power plant with CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+- Capital Cost|Electricity|Biomass|{CCS}:
+    description: Capital cost of a new biomass power plant {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Electricity|Biomass|w/o CCS:
-    description: capital cost of a new biomass power plant w/o CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
+- Capital Cost|Electricity|{Non-Biomass Renewables}:
+    description: Capital cost of a new {Non-Biomass Renewables} power plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Electricity|Coal|w/ CCS:
-    description: capital cost of a new coal power plant with CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Electricity|Coal|w/o CCS:
-    description: capital cost of a new coal power plant w/o CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Electricity|Gas|w/ CCS:
-    description: capital cost of a new gas power plant with CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Electricity|Gas|w/o CCS:
-    description: capital cost of a new gas power plant w/o CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Electricity|Geothermal:
-    description: capital cost of a new geothermal power plant. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Electricity|Hydro:
-    description: capital cost of a new hydropower plant. If more than technology in
-      this category is modelled, modellers should report capital costs for the technology
-      that is used most; please specify the technology name/characteristics in the
-      comments.
+- Capital Cost|Electricity|{Primary Fossil Fuel}|{CCS}:
+    description: Capital cost of a new power plant for {Primary Fossil Fuel} {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Electricity|Nuclear:
-    description: capital cost of a new nuclear power plants. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
+    description: Capital cost of a new nuclear power plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Electricity|Solar|CSP:
-    description: capital cost of a new concentrated solar power plant. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+
+- Capital Cost|Gases|Biomass|{CCS}:
+    description: Capital cost of a new biomass-to-gas plant {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Electricity|Solar|PV:
-    description: capital cost of a new solar PV units. If more than technology in
-      this category is modelled, modellers should report capital costs for the technology
-      that is used most; please specify the technology name/characteristics in the
-      comments.
+- Capital Cost|Gases|Coal|{CCS}:
+    description: Capital cost of a new coal-to-gas plant {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Electricity|Wind|Offshore:
-    description: capital cost of a new offshore wind power plants. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
+
+- Capital Cost|Hydrogen|Biomass|{CCS}:
+    description: Capital cost of a new biomass-to-hydrogen plant {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Electricity|Wind|Onshore:
-    description: capital cost of a new onshore wind power plants. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
+- Capital Cost|Hydrogen|Coal|{CCS}:
+    description: Capital cost of a new coal-to-hydrogen plant {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Gases|Biomass|w/ CCS:
-    description: capital cost of a new biomass to gas plant with CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Gases|Biomass|w/o CCS:
-    description: capital cost of a new biomass to gas plant w/o CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Gases|Coal|w/ CCS:
-    description: capital cost of a new coal to gas plant with CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Gases|Coal|w/o CCS:
-    description: capital cost of a new coal to gas plant w/o CCS. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Hydrogen|Biomass|w/ CCS:
-    description: capital cost of a new biomass to hydrogen plant with CCS. If more
-      than technology in this category is modelled, modellers should report capital
-      costs for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Hydrogen|Biomass|w/o CCS:
-    description: capital cost of a new biomass to hydrogen plant w/o CCS. If more
-      than technology in this category is modelled, modellers should report capital
-      costs for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Hydrogen|Coal|w/ CCS:
-    description: capital cost of a new coal to hydrogen plant with CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Hydrogen|Coal|w/o CCS:
-    description: capital cost of a new coal to hydrogen plant w/o CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+- Capital Cost|Hydrogen|Gas|{CCS}:
+    description: Capital cost of a new gas-to-hydrogen plant {CCS}
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Hydrogen|Electricity:
-    description: capital cost of a new hydrogen-by-electrolysis plant. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+    description: Capital cost of a new electrolysis plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Hydrogen|Gas|w/ CCS:
-    description: capital cost of a new gas to hydrogen plant with CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+
+- Capital Cost|Liquids|Biomass:
+    description: Capital cost of a new biomass-to-liquids plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Hydrogen|Gas|w/o CCS:
-    description: capital cost of a new gas to hydrogen plant w/o CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+- Capital Cost|Liquids|Coal:
+    description: Capital cost of a new coal-to-liquids plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Liquids|Biomass|w/ CCS:
-    description: capital cost of a new biomass to liquids plant with CCS. If more
-      than technology in this category is modelled, modellers should report capital
-      costs for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Biomass|w/o CCS:
-    description: capital cost of a new biomass to liquids plant w/o CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Coal|w/ CCS:
-    description: capital cost of a new coal to liquids plant with CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Coal|w/o CCS:
-    description: capital cost of a new coal to liquids plant w/o CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Gas|w/ CCS:
-    description: capital cost of a new gas to liquids plant with CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Gas|w/o CCS:
-    description: capital cost of a new gas to liquids plant w/o CCS. If more than
-      technology in this category is modelled, modellers should report capital costs
-      for the technology that is used most; please specify the technology name/characteristics
-      in the comments.
+- Capital Cost|Liquids|Gas:
+    description: Capital cost of a new gas-to-liquids plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Liquids|Oil:
-    description: capital cost of a new oil refining plant. If more than technology
-      in this category is modelled, modellers should report capital costs for the
-      technology that is used most; please specify the technology name/characteristics
-      in the comments.
+    description: Capital cost of a new oil refining plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
     unit: USD_2010/kW
+
 - Efficiency|Electricity|Biomass|w/ CCS:
     description: 'Conversion efficiency (electricity produced per unit of primary
       energy input) of a new biomass power plant with CCS. The efficiency should refer

--- a/definitions/variable/techno-economic/techno-economic-parameters.yaml
+++ b/definitions/variable/techno-economic/techno-economic-parameters.yaml
@@ -19,13 +19,13 @@
       capital costs for the technology that is used most.
     unit: USD_2010/kW
 
-- Capital Cost|Gases|Biomass|{CCS}:
-    description: Capital cost of a new biomass-to-gas plant {CCS}
+- Capital Cost|Gases|Biomass:
+    description: Capital cost of a new biomass-to-gas plant
     note: If more than technology in this category is modelled, modellers should report
       capital costs for the technology that is used most.
     unit: USD_2010/kW
-- Capital Cost|Gases|Coal|{CCS}:
-    description: Capital cost of a new coal-to-gas plant {CCS}
+- Capital Cost|Gases|Coal:
+    description: Capital cost of a new coal-to-gas plant
     note: If more than technology in this category is modelled, modellers should report
       capital costs for the technology that is used most.
     unit: USD_2010/kW

--- a/definitions/variable/techno-economic/techno-economic-parameters.yaml
+++ b/definitions/variable/techno-economic/techno-economic-parameters.yaml
@@ -19,6 +19,27 @@
       capital costs for the technology that is used most.
     unit: USD_2010/kW
 
+- Capital Cost|Liquids|Biomass:
+    description: Capital cost of a new biomass-to-liquids plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
+    unit: USD_2010/kW
+- Capital Cost|Liquids|Coal:
+    description: Capital cost of a new coal-to-liquids plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
+    unit: USD_2010/kW
+- Capital Cost|Liquids|Gas:
+    description: Capital cost of a new gas-to-liquids plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
+    unit: USD_2010/kW
+- Capital Cost|Liquids|Oil:
+    description: Capital cost of a new oil refining plant
+    note: If more than technology in this category is modelled, modellers should report
+      capital costs for the technology that is used most.
+    unit: USD_2010/kW
+
 - Capital Cost|Gases|Biomass:
     description: Capital cost of a new biomass-to-gas plant
     note: If more than technology in this category is modelled, modellers should report
@@ -47,27 +68,6 @@
     unit: USD_2010/kW
 - Capital Cost|Hydrogen|Electricity:
     description: Capital cost of a new electrolysis plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
-    unit: USD_2010/kW
-
-- Capital Cost|Liquids|Biomass:
-    description: Capital cost of a new biomass-to-liquids plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Coal:
-    description: Capital cost of a new coal-to-liquids plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Gas:
-    description: Capital cost of a new gas-to-liquids plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
-    unit: USD_2010/kW
-- Capital Cost|Liquids|Oil:
-    description: Capital cost of a new oil refining plant
     note: If more than technology in this category is modelled, modellers should report
       capital costs for the technology that is used most.
     unit: USD_2010/kW

--- a/definitions/variable/techno-economic/techno-economic-parameters.yaml
+++ b/definitions/variable/techno-economic/techno-economic-parameters.yaml
@@ -1,75 +1,75 @@
 - Capital Cost|Electricity|Biomass|{CCS}:
     description: Capital cost of a new biomass power plant {CCS}
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Electricity|{Non-Biomass Renewables}:
     description: Capital cost of a new {Non-Biomass Renewables} power plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Electricity|{Primary Fossil Fuel}|{CCS}:
     description: Capital cost of a new power plant for {Primary Fossil Fuel} {CCS}
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Electricity|Nuclear:
     description: Capital cost of a new nuclear power plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 
 - Capital Cost|Liquids|Biomass:
     description: Capital cost of a new biomass-to-liquids plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Liquids|Coal:
     description: Capital cost of a new coal-to-liquids plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Liquids|Gas:
     description: Capital cost of a new gas-to-liquids plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Liquids|Oil:
     description: Capital cost of a new oil refining plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 
 - Capital Cost|Gases|Biomass:
     description: Capital cost of a new biomass-to-gas plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Gases|Coal:
     description: Capital cost of a new coal-to-gas plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 
 - Capital Cost|Hydrogen|Biomass|{CCS}:
     description: Capital cost of a new biomass-to-hydrogen plant {CCS}
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Hydrogen|Coal|{CCS}:
     description: Capital cost of a new coal-to-hydrogen plant {CCS}
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Hydrogen|Gas|{CCS}:
     description: Capital cost of a new gas-to-hydrogen plant {CCS}
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 - Capital Cost|Hydrogen|Electricity:
     description: Capital cost of a new electrolysis plant
-    note: If more than technology in this category is modelled, modellers should report
-      capital costs for the technology that is used most.
+    note: If more than one technology in this category is represented in the model,
+      modellers should report parameters for the technology that is used most.
     unit: USD_2010/kW
 
 - Efficiency|Electricity|Biomass|w/ CCS:


### PR DESCRIPTION
This PR introduces tag-lists `{CCS}` and `{Non-Biomass Renewables}` - the **nomenclature** package then automatically creates all possible permutations from [here](https://github.com/IAMconsortium/common-definitions/blob/main/definitions/variable/energy/tag_ccs.yaml) and [here](https://github.com/IAMconsortium/common-definitions/blob/main/definitions/variable/energy/tag_non_biomass_renewables.yaml) so that the yaml files are more concise and easier to read (and reducing errors from copy-pasting).

In the process, I realized that in NAVIGATE and AR6, we had variables like "Capital Cost|Liquids|Gas|w/ CCS" - however, if the output of the gas-to-liquid-plant is still a hydrocarbon-based fuel, there is no CCS-component at that plant.

Please discuss - I can then also convert the other variables in this file to the tag-list structure.